### PR TITLE
Unable to access the WebEvent data from within a custom ConsoleLogger listener instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ lerna-debug.log
 *.tsbuildinfo
 .angular
 packages/website/src/assets/docs
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # ⏭ vNext
+# v3.13.0
+- `@/web-server`
+    * Added the WebEventZone to the default request logging context to allow custom console logger implementations to access the current 
+      WebEvent instance.
 
 # v3.12.0
 - `@/web-server`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # ⏭ vNext
-# v3.13.0
 - `@/web-server`
     * Added the WebEventZone to the default request logging context to allow custom console logger implementations to access the current 
       WebEvent instance.

--- a/packages/web-server/src/web-server.ts
+++ b/packages/web-server/src/web-server.ts
@@ -274,7 +274,7 @@ export class WebServer {
 		if (!this.requestReporterFilters.every(x => x(event, source)))
 			return;
 
-		this.requestReporter(reportingEvent, event, source, this.logger);
+		event.context(() => this.requestReporter(reportingEvent, event, source, this.logger));
 	}
 
 	get sensitiveParameters() {


### PR DESCRIPTION
Added the WebEventZone to the default request logging context to allow custom console logger implementations to access the current WebEvent instance.